### PR TITLE
INT-1308: Ensure secondary reads can happen on commands.

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -9,6 +9,8 @@ var async = require('async');
 var mongodbNS = require('mongodb-ns');
 var secondaryPreferred = require('mongodb-read-preference').secondaryPreferred;
 
+var OPTIONS = { readPreference: secondaryPreferred };
+
 // var debug = require('debug')('mongodb-index-model:fetch');
 
 /**
@@ -28,8 +30,7 @@ function attach(anything, done) {
 function getIndexes(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
-  var options = { readPreference: secondaryPreferred };
-  db.db(ns.database).collection(ns.collection).listIndexes(options).toArray(function(err, indexes) {
+  db.db(ns.database).collection(ns.collection).listIndexes(OPTIONS).toArray(function(err, indexes) {
     if (err) {
       done(err);
     }
@@ -50,12 +51,11 @@ function getIndexStats(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
   var pipeline = [
-   { $indexStats: { } },
-   { $project: { name: 1, usageHost: '$host', usageCount: '$accesses.ops', usageSince: '$accesses.since' } }
+    { $indexStats: { } },
+    { $project: { name: 1, usageHost: '$host', usageCount: '$accesses.ops', usageSince: '$accesses.since' } }
   ];
-  var options = { readPreference: secondaryPreferred };
   var collection = db.db(ns.database).collection(ns.collection);
-  collection.aggregate(pipeline, options, function(err, res) {
+  collection.aggregate(pipeline, OPTIONS, function(err, res) {
     if (err) {
       if (err.message.match(/Unrecognized pipeline stage name/)) {
         // $indexStats not yet supported, return empty document
@@ -79,8 +79,7 @@ function getIndexStats(done, results) {
 function getIndexSizes(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
-  var options = { readPreference: secondaryPreferred };
-  db.db(ns.database).collection(ns.collection).stats(options, function(err, res) {
+  db.db(ns.database).collection(ns.collection).stats(OPTIONS, function(err, res) {
     if (err) {
       done(err);
     }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -7,6 +7,7 @@
 var _ = require('lodash');
 var async = require('async');
 var mongodbNS = require('mongodb-ns');
+var secondaryPreferred = require('mongodb-read-preference').secondaryPreferred;
 
 // var debug = require('debug')('mongodb-index-model:fetch');
 
@@ -27,7 +28,8 @@ function attach(anything, done) {
 function getIndexes(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
-  db.db(ns.database).collection(ns.collection).indexes(function(err, indexes) {
+  var options = { readPreference: secondaryPreferred };
+  db.db(ns.database).collection(ns.collection).listIndexes(options).toArray(function(err, indexes) {
     if (err) {
       done(err);
     }
@@ -48,11 +50,12 @@ function getIndexStats(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
   var pipeline = [
-    { $indexStats: { } },
-    { $project: { name: 1, usageHost: '$host', usageCount: '$accesses.ops', usageSince: '$accesses.since' } }
+   { $indexStats: { } },
+   { $project: { name: 1, usageHost: '$host', usageCount: '$accesses.ops', usageSince: '$accesses.since' } }
   ];
+  var options = { readPreference: secondaryPreferred };
   var collection = db.db(ns.database).collection(ns.collection);
-  collection.aggregate(pipeline, function(err, res) {
+  collection.aggregate(pipeline, options, function(err, res) {
     if (err) {
       if (err.message.match(/Unrecognized pipeline stage name/)) {
         // $indexStats not yet supported, return empty document
@@ -76,7 +79,8 @@ function getIndexStats(done, results) {
 function getIndexSizes(done, results) {
   var db = results.db;
   var ns = mongodbNS(results.namespace);
-  db.db(ns.database).collection(ns.collection).stats(function(err, res) {
+  var options = { readPreference: secondaryPreferred };
+  db.db(ns.database).collection(ns.collection).stats(options, function(err, res) {
     if (err) {
       done(err);
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "async": "^1.5.2",
     "lodash": "^4.8.2",
     "mongodb-ns": "^1.0.3",
+    "mongodb-read-preference": "^1.0.6",
     "triejs": "github:rueckstiess/triejs"
   },
   "devDependencies": {

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -7,8 +7,8 @@ var _ = require('lodash');
 // var debug = require('debug')('mongodb-index-model:text:fetch');
 
 describe('fetch()', function() {
-  before(require('mongodb-runner/mocha/before')());
-  after(require('mongodb-runner/mocha/after')());
+  before(require('mongodb-runner/mocha/before')({ port: 27018 }));
+  after(require('mongodb-runner/mocha/after')({ port: 27018 }));
 
   context('local', function() {
     this.slow(2000);
@@ -19,7 +19,7 @@ describe('fetch()', function() {
 
     // connect and create collection with index
     before(function(done) {
-      MongoClient.connect('mongodb://localhost:27017/test', function(err, _db) {
+      MongoClient.connect('mongodb://localhost:27018/test', function(err, _db) {
         assert.ifError(err);
         db = _db;
         collection = db.collection('_test_index_fetch');
@@ -35,7 +35,7 @@ describe('fetch()', function() {
       collection.drop(done);
     });
 
-    it('should connect to `localhost:27017` and get indexes', function(done) {
+    it('should connect to `localhost:27018` and get indexes', function(done) {
       fetch(db, 'test._test_index_fetch', function(err, res) {
         assert.ifError(err);
         assert.equal(res[0].name, '_id_');


### PR DESCRIPTION
Without the read preference explicitly set the tests failed when pointed as a secondary of a replica set with the standard "not master" errors. Part of INT-1308.

Also made test runner use port 27018 not to conflict with those already running an instance on 27017.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/index-model/15)
<!-- Reviewable:end -->
