### PR TITLE
Fix runner failures on travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "fmt": "mongodb-js-fmt test/*.js bin/*.js index.js",
     "check": "mongodb-js-precommit",
     "ci": "npm run check && npm test",
-    "test": "mocha"
+    "pretest": "mongodb-runner install && mongodb-runner start",
+    "test": "mocha",
+    "posttest": "mongodb-runner stop"
   },
   "precommit": [
     "check"

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -7,9 +7,6 @@ var _ = require('lodash');
 // var debug = require('debug')('mongodb-index-model:text:fetch');
 
 describe('fetch()', function() {
-  before(require('mongodb-runner/mocha/before')());
-  after(require('mongodb-runner/mocha/after')());
-
   context('local', function() {
     this.slow(2000);
     this.timeout(10000);


### PR DESCRIPTION
IIRC Travis (and local) sometimes times out when downloading MongoDB. If this removes that then we should merge it and apply the pattern more generally so we don't have the *sometimes* fails, especially when a new version of MongoDB is released.